### PR TITLE
Fix async mqtt

### DIFF
--- a/ports/async-mqtt/patch-install.diff
+++ b/ports/async-mqtt/patch-install.diff
@@ -1,0 +1,16 @@
+commit cb40240506bd1b1614abdeb2ec7a0d14419072b8
+Author: Jón Bjarni <jbbjarnason@gmail.com>
+Date:   Mon Jun 24 11:37:45 2024 +0000
+
+    install *.ipp files along with other header files
+
+diff --git a/include/CMakeLists.txt b/include/CMakeLists.txt
+index 67d87746..69c7752d 100644
+--- a/include/CMakeLists.txt
++++ b/include/CMakeLists.txt
+@@ -23,4 +23,4 @@ target_compile_definitions(${PROJECT_NAME} INTERFACE $<$<BOOL:${ASYNC_MQTT_USE_S
+ target_compile_definitions(${PROJECT_NAME} INTERFACE $<$<BOOL:${ASYNC_MQTT_USE_LOG}>:ASYNC_MQTT_USE_LOG>)
+ target_compile_definitions(${PROJECT_NAME} INTERFACE $<$<BOOL:${ASYNC_MQTT_PRINT_PAYLOAD}>:ASYNC_MQTT_PRINT_PAYLOAD>)
+ 
+-install(DIRECTORY . DESTINATION include FILES_MATCHING PATTERN "*.hpp" PATTERN "*.h")
++install(DIRECTORY . DESTINATION include FILES_MATCHING PATTERN "*.hpp" PATTERN "*.h" PATTERN "*.ipp")

--- a/ports/async-mqtt/portfile.cmake
+++ b/ports/async-mqtt/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_github(
     REF "${VERSION}"
     SHA512 1e4c1ecb10de7f7554fbbf9c05be4d6d8399d40e52f54203f8ce246606b146ff26e5a5fd9dedb4b2c9067ff44f891e55897a27da7b6bd34db308c30aaf6c1f7b
     HEAD_REF main
+    PATCHES
+      patch-install.diff
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/ports/async-mqtt/vcpkg.json
+++ b/ports/async-mqtt/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "async-mqtt",
   "version": "7.0.0",
+  "port-version": 1,
   "description": "Header-only Asynchronous MQTT communication library for C++17 based on Boost.Asio.",
   "homepage": "https://github.com/redboltz/async_mqtt",
   "license": "BSL-1.0",

--- a/versions/a-/async-mqtt.json
+++ b/versions/a-/async-mqtt.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "873fa0ed699c3a04053d829ea7eb361934a8b34a",
+      "version": "7.0.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "286bc76359a1cd98053b0a9a8ff81047ebf663ad",
       "version": "7.0.0",
       "port-version": 0

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -286,7 +286,7 @@
     },
     "async-mqtt": {
       "baseline": "7.0.0",
-      "port-version": 0
+      "port-version": 1
     },
     "async-simple": {
       "baseline": "1.3",


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/. -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
